### PR TITLE
js: change nodejs version

### DIFF
--- a/.github/workflows/tests-js.yml
+++ b/.github/workflows/tests-js.yml
@@ -10,7 +10,7 @@ on:
       node-version:
         description: "Node versions"
         type: string
-        default: '["18.x", "20.x"]'
+        default: '["22.x"]'
       js-working-directory:
         description: "Working directory"
         type: string


### PR DESCRIPTION
* endoflife of nodejs v18

* testing against one nodejs version is enough, and v22 is already one year old and also an LTS version

