### PR TITLE
ci: add optional js compile step to publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2024 CERN.
+# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2025 KTH Royal Institute of Technology.
 
 name: Publish on PyPI
 
@@ -8,10 +10,20 @@ on:
   workflow_call:
     inputs:
       babel-compile-catalog:
-        description: 'Run Babel compile_catalog cmd'
+        description: "Run Babel compile_catalog cmd"
         required: false
         default: false
         type: boolean
+      js-translations-working-directory:
+        description: "Path to frontend translations directory (leave blank to skip)"
+        required: false
+        default: ""
+        type: string
+      node-version:
+        description: "Node.js version used when compiling JS assets"
+        required: false
+        default: "22"
+        type: string
 
 jobs:
   Build-N-Publish:
@@ -34,6 +46,20 @@ jobs:
         run: |
           python -m pip install babel
           python setup.py compile_catalog
+
+      - name: Setup node
+        if: ${{ inputs.js-translations-working-directory != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Build frontend translations
+        if: ${{ inputs.js-translations-working-directory != '' }}
+        working-directory: ${{ inputs.js-translations-working-directory }}
+        run: |
+          npm ci
+          npm list
+          npm run compile_catalog
 
       - name: Build package
         run: |


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Originally introduced in: https://github.com/inveniosoftware/invenio-requests/pull/408/files#diff-29239970d55958739fb39189ad2b2b5afe4184fc541ccaa9ee3f91be06877f0f



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
