### PR TITLE
publish: add js translation dir detection step

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Pre-install
         uses: ./.github/actions/pre-install
@@ -71,7 +71,9 @@ jobs:
           npm ci
           npm list
           npm run compile_catalog
-
+          echo "cleaning up node_modules ..."
+          rm -rf node_modules
+          echo "node_modules removed from final distribution."
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -71,9 +71,17 @@ jobs:
           npm ci
           npm list
           npm run compile_catalog
-          echo "cleaning up node_modules ..."
-          rm -rf node_modules
-          echo "node_modules removed from final distribution."
+          echo "cleaning up node_modules and dev files..."
+          rm -rf node_modules scripts
+          rm -f package-lock.json i18next-scanner.config.js
+          echo "Cleaned up frontend build artifacts and development dependencies."
+
+      - name: Remove unnecessary files before packaging
+        run: |
+          echo "Removing docs, tests, .github, and .tx directories..."
+          rm -rf docs tests .github .tx
+          echo "Unnecessary directories removed from final distribution."
+
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -44,15 +44,15 @@ jobs:
         id: determine_js_path
         run: |
           PACKAGE_NAME=$(basename "$PWD" | tr '-' '_')
-          THEME_PATH="$PACKAGE_NAME/theme/assets/semantic-ui/translations/$PACKAGE_NAME"
-          DEFAULT_PATH="$PACKAGE_NAME/assets/semantic-ui/translations/$PACKAGE_NAME"
+          APP_RDM_TRANSLATIONS_PATH="$PACKAGE_NAME/theme/assets/semantic-ui/translations/$PACKAGE_NAME"
+          DEFAULT_TRANSLATIONS_PATH="$PACKAGE_NAME/assets/semantic-ui/translations/$PACKAGE_NAME"
 
-          if [ -f "$THEME_PATH/package.json" ]; then
-            echo "Found package.json in theme path: $THEME_PATH"
-            echo "translation_dir=$THEME_PATH" >> $GITHUB_OUTPUT # make path visible to subsequent steps
-          elif [ -f "$DEFAULT_PATH/package.json" ]; then
-            echo "Found package.json in default path: $DEFAULT_PATH"
-            echo "translation_dir=$DEFAULT_PATH" >> $GITHUB_OUTPUT
+          if [ -f "$APP_RDM_TRANSLATIONS_PATH/package.json" ]; then
+            echo "Found package.json in theme path: $APP_RDM_TRANSLATIONS_PATH"
+            echo "translation_dir=$APP_RDM_TRANSLATIONS_PATH" >> $GITHUB_OUTPUT # make path visible to subsequent steps
+          elif [ -f "$DEFAULT_TRANSLATIONS_PATH/package.json" ]; then
+            echo "Found package.json in default path: $DEFAULT_TRANSLATIONS_PATH"
+            echo "translation_dir=$DEFAULT_TRANSLATIONS_PATH" >> $GITHUB_OUTPUT
           else
             echo "No JS translation directory found"
             echo "translation_dir=" >> $GITHUB_OUTPUT

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2024 CERN.
+# Copyright (C) 2025 KTH Royal Institute of Technology.
 
 name: Publish on PyPI
 
@@ -38,6 +39,38 @@ jobs:
         run: |
           python -m pip install babel
           python setup.py compile_catalog
+
+      - name: Determine JS translation directory
+        id: determine_js_path
+        run: |
+          PACKAGE_NAME=$(basename "$PWD" | tr '-' '_')
+          THEME_PATH="$PACKAGE_NAME/theme/assets/semantic-ui/translations/$PACKAGE_NAME"
+          DEFAULT_PATH="$PACKAGE_NAME/assets/semantic-ui/translations/$PACKAGE_NAME"
+
+          if [ -f "$THEME_PATH/package.json" ]; then
+            echo "Found package.json in theme path: $THEME_PATH"
+            echo "translation_dir=$THEME_PATH" >> $GITHUB_OUTPUT # make path visible to subsequent steps
+          elif [ -f "$DEFAULT_PATH/package.json" ]; then
+            echo "Found package.json in default path: $DEFAULT_PATH"
+            echo "translation_dir=$DEFAULT_PATH" >> $GITHUB_OUTPUT
+          else
+            echo "No JS translation directory found"
+            echo "translation_dir=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Node
+        if: ${{ steps.determine_js_path.outputs.translation_dir != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*" # latest active LTS release
+
+      - name: Build frontend translations
+        if: ${{ steps.determine_js_path.outputs.translation_dir != '' }}
+        working-directory: ${{ steps.determine_js_path.outputs.translation_dir }}
+        run: |
+          npm ci
+          npm list
+          npm run compile_catalog
 
       - name: Build package
         run: |


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* This update introduces steps to determine the JS translation
   directory and compile frontend translations if applicable.
* The workflow now checks for package.json in both
   theme: (invenio-app-rdm) and default (rest of packages)
* We remove the tests and docs folders so we don't have
   to add these to the ignore list in each package
* Removing development files and
  unnecessary directories before packaging.
* Reduce the final package size
* Another explicit approach in this draft PR: https://github.com/inveniosoftware/workflows/pull/4



<details>
<summary>For easy review, you can test it locally using this script 👇</summary>


```sh
#!/bin/bash

# Test script for PyPI publish workflow
# This replicates the steps from the GitHub Actions publish workflow locally

set -e  # Exit on any error

echo "=== Testing PyPI Publish Workflow Locally ==="
echo

# Step 1: Install Python dependencies
echo "📦 Installing Python dependencies..."
python -m pip install --upgrade pip -q
python -m pip install build -q
python -m pip install babel -q

# Step 2: Compile Python catalog
echo "🐍 Compiling Python catalog..."
python setup.py compile_catalog

# Step 3: Determine JS translation directory
echo "🔍 Determining JS translation directory..."
PACKAGE_NAME=$(basename "$PWD" | tr '-' '_')
echo "Package name: $PACKAGE_NAME"

THEME_PATH="$PACKAGE_NAME/theme/assets/semantic-ui/translations/$PACKAGE_NAME"
DEFAULT_PATH="$PACKAGE_NAME/assets/semantic-ui/translations/$PACKAGE_NAME"

if [ -f "$THEME_PATH/package.json" ]; then
    echo "✅ Found package.json in theme path: $THEME_PATH"
    TRANSLATION_DIR="$THEME_PATH"
elif [ -f "$DEFAULT_PATH/package.json" ]; then
    echo "✅ Found package.json in default path: $DEFAULT_PATH"
    TRANSLATION_DIR="$DEFAULT_PATH"
else
    echo "❌ No JS translation directory found"
    TRANSLATION_DIR=""
fi

echo "Translation directory: $TRANSLATION_DIR"

# Step 4: Setup Node and build frontend translations (if directory exists)
if [ -n "$TRANSLATION_DIR" ]; then
    echo
    echo "🟢 Node.js setup and frontend translation build..."

    # Check if Node.js is installed
    if ! command -v node &> /dev/null; then
        echo "❌ Node.js is not installed. Please install Node.js first."
        exit 1
    fi

    echo "Node.js version: $(node --version)"
    echo "npm version: $(npm --version)"

    # Change to translation directory
    cd "$TRANSLATION_DIR"
    echo "Working directory: $(pwd)"

    echo
    echo "📋 Installing npm dependencies..."
    npm ci

    echo
    echo "📦 Listing installed packages..."
    npm list

    echo
    echo "🔨 Compiling catalog..."
    npm run compile_catalog
    echo "cleaning up node_modules and dev files..."
    rm -rf node_modules
    rm -f package-lock.json i18next-scanner.config.js
    rm -rf scripts
    echo "Cleaned up frontend build artifacts and development dependencies."

    # Return to project root
    cd - > /dev/null
    echo "✅ Frontend translations built successfully!"
else
    echo "⚠️  Skipping Node.js setup - no JS translation directory found"
fi

# Step 5: Remove unnecessary files before packaging
echo
echo "🧹 Removing docs, tests, .github, and .tx directories..."
rm -rf docs tests .github .tx
echo "Unnecessary directories removed from final distribution."

# Step 6: Build package
echo
echo "📦 Building package..."
python -m build

echo
echo "🎉 All steps completed successfully!"
echo
echo "Summary:"
echo "- Python catalog compiled: ✅"
echo "- JS translation directory: ${TRANSLATION_DIR:-"Not found"}"
if [ -n "$TRANSLATION_DIR" ]; then
    echo "- Frontend translations compiled: ✅"
else
    echo "- Frontend translations compiled: ⚠️  Skipped"
fi
echo "- Unnecessary files removed: ✅"
echo "- Package built: ✅"

# Step 7: Cleanup installed packages (for local setup not part of the workflow!)
echo
echo "🧹 Cleaning up installed packages..."
echo "Uninstalling test dependencies: build, babel"
pip freeze > r.txt
pip uninstall -r r.txt -y || echo "Something went wrong while removing py deps"
# rm r.txt

echo "✅ Done!"


```

</details>

You can run the script with `./test_publish_workflow.sh > output.log 2>&1`


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license), including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
