### PR TITLE
fix: python3.12 misses setuptools

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2024 CERN.
 # Copyright (C) 2025 KTH Royal Institute of Technology.
+# Copyright (C) 2025 Graz University of Technology.
 
 name: Publish on PyPI
 
@@ -32,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build twine
+          python -m pip install build twine setuptools
 
       - name: Compile catalog
         if: ${{ fromJSON(inputs.babel-compile-catalog) }}


### PR DESCRIPTION
* package is not more default of python3.12
