### PR TITLE
js-tests: add translation build to tests

### DIFF
--- a/.github/workflows/tests-js.yml
+++ b/.github/workflows/tests-js.yml
@@ -44,16 +44,39 @@ jobs:
       - name: Run eslint test
         run: ./run-js-linter.sh -i
 
+      - name: Determine JS translation directory
+        id: determine_js_path
+        run: |
+          PACKAGE_NAME=$(basename "$PWD" | tr '-' '_')
+          APP_RDM_TRANSLATIONS_PATH="$PACKAGE_NAME/theme/assets/semantic-ui/translations/$PACKAGE_NAME"
+          DEFAULT_TRANSLATIONS_PATH="$PACKAGE_NAME/assets/semantic-ui/translations/$PACKAGE_NAME"
+
+          if [ -f "$APP_RDM_TRANSLATIONS_PATH/package.json" ]; then
+            echo "Found package.json in theme path: $APP_RDM_TRANSLATIONS_PATH"
+            echo "translation_dir=$APP_RDM_TRANSLATIONS_PATH" >> $GITHUB_OUTPUT # make path visible to subsequent steps
+          elif [ -f "$DEFAULT_TRANSLATIONS_PATH/package.json" ]; then
+            echo "Found package.json in default path: $DEFAULT_TRANSLATIONS_PATH"
+            echo "translation_dir=$DEFAULT_TRANSLATIONS_PATH" >> $GITHUB_OUTPUT
+          else
+            echo "No JS translation directory found"
+            echo "translation_dir=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build frontend translations
+        if: ${{ steps.determine_js_path.outputs.translation_dir != '' }}
+        working-directory: ${{ steps.determine_js_path.outputs.translation_dir }}
+        run: |
+          npm ci
+          npm list
+          npm run compile_catalog
+          echo "cleaning up node_modules and dev files..."
+          rm -rf node_modules scripts
+          rm -f package-lock.json i18next-scanner.config.js
+          echo "Cleaned up frontend build artifacts and development dependencies."
+
       - name: Install deps for frontend tests
         if: ${{ inputs.js-working-directory != '' }}
         working-directory: ${{ inputs.js-working-directory }}
-        run: |
-          npm install
-          npm list
-
-      - name: Install deps for frontend tests - translations
-        if: ${{ inputs.translations-working-directory != '' }}
-        working-directory: ${{ inputs.translations-working-directory }}
         run: |
           npm install
           npm list


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

We should include the js translation build steps in the CI, to avoid issues like https://github.com/inveniosoftware/invenio-app-rdm/actions/runs/16355943075/job/46214227478 that only show up when running the release.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
