### PR TITLE
feat: add commit linter

### DIFF
--- a/.github/workflows/tests-python.yml
+++ b/.github/workflows/tests-python.yml
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2024 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 
 name: Python CI
 
@@ -43,6 +44,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: commitlint
+        uses: wagoid/commitlint-github-action@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
* uses https://github.com/conventional-changelog/commitlint to lint
  commit messages
https://www.conventionalcommits.org/en/v1.0.0/