### PR TITLE
tests(uv): extend uv Python test window to 3.14 [+]

### DIFF
--- a/.github/workflows/tests-python.yml
+++ b/.github/workflows/tests-python.yml
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2024 CERN.
+# Copyright (C) 2025 Northwestern University.
 
 name: Python CI
 
@@ -11,7 +12,7 @@ on:
         description: "Python versions"
         type: string
         # NOTE: There is no "array" type, so we use "string" and parse it in the matrix
-        default: '["3.9", "3.12"]'
+        default: '["3.9", "3.11", "3.14.0"]'
       extras:
         description: "Extra dependencies"
         type: string
@@ -27,7 +28,7 @@ on:
 
 jobs:
   Tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -43,15 +44,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3  # v7.1.3
         with:
           enable-cache: true
 


### PR DESCRIPTION
- switch to ubuntu-latest
- use hash for third-party actions for security

It turns out that at least invenio-github uses the uv branch : https://github.com/inveniosoftware/invenio-github/blob/master/.github/workflows/tests.yml#L31 . And the other niceties are mostly future-proofing in case this becomes the main test workflow for python.