### PR TITLE
feat(tests-js): support custom run-js-tests.sh script

### DIFF
--- a/.github/workflows/tests-js.yml
+++ b/.github/workflows/tests-js.yml
@@ -61,4 +61,13 @@ jobs:
       - name: Run frontend tests
         if: ${{ inputs.js-working-directory != '' }}
         working-directory: ${{ inputs.js-working-directory }}
-        run: npm test
+        env:
+          WORKING_DIR: ${{ inputs.js-working-directory }}
+          CI: true
+        run: |
+          if [ -f "${{ github.workspace }}/run-js-tests.sh" ]; then
+            ${{ github.workspace }}/run-js-tests.sh
+          else
+            echo "Warning: run-js-tests.sh not found, falling back to 'npm test'"
+            npm test
+          fi

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This workflow will:
 3. Run the linter using the `./run-js-linter.sh` script in the repository.
 4. Install test dependencies if the `js-working-directory` input is set.
 5. Install frontend dependencies if the `translations-working-directory` input is set.
-6. Run the tests using the `./run-js-tests.sh` script in the repository.
+6. Run the tests using the `./run-js-tests.sh` script in the repository (falls back to `npm test` if not present).
 
 To use in your repository, add the following in your `.github/workflows/tests.yml` file under the `jobs` key:
 


### PR DESCRIPTION
## Summary

Adds support for testing repositories that provide a `run-js-tests.sh` script for JavaScript test execution. Falls back to `npm test` if the script is not present, maintaining backward compatibility.

## Changes

- Attempts to execute `${{ github.workspace }}/run-js-tests.sh`
- Falls back to `npm test` with warning if script not found
- Passes `WORKING_DIR` and `CI` environment variables to the script

Implementation of Phase0 of RFC: https://github.com/inveniosoftware/rfcs/pull/112

## Related PRs

The following repositories need to add `run-js-tests.sh` to use this:

### Core modules
- [x] (https://github.com/inveniosoftware/invenio-rdm-records/pull/2321)
- [ ] invenio-communities  
- [ ] invenio-app-rdm
- [ ] invenio-requests
- [ ] invenio-administration

### UI modules
- [ ] invenio-search-ui
- [ ] invenio-theme
- [ ] invenio-previewer
- [ ] invenio-userprofiles

### React libraries
- [ ] react-invenio-app-ils
- [ ] react-invenio-forms
- [x] (https://github.com/inveniosoftware/react-searchkit/pull/298)

### Other modules with JS
- [ ] invenio-accounts
- [ ] invenio-vocabularies
- [ ] invenio-checks
- [ ] invenio-collections
- [ ] invenio-banners