### PR TITLE
feat: support pyproject catalog compile

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2024 CERN.
-# SPDX-FileCopyrightText: 2025 KTH Royal Institute of Technology.
+# SPDX-FileCopyrightText: 2025-2026 KTH Royal Institute of Technology.
 # SPDX-FileCopyrightText: 2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
@@ -13,6 +13,11 @@ on:
         required: false
         default: false
         type: boolean
+      backend-package-path:
+        description: 'Python package path for pyproject.toml based Babel catalogs'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   Build-N-Publish:
@@ -36,11 +41,25 @@ jobs:
           python -m pip install build twine
 
       - name: Compile catalog
-        if: ${{ fromJSON(inputs.babel-compile-catalog) }}
+        if: ${{ fromJSON(inputs.babel-compile-catalog) && inputs.backend-package-path == '' }}
         run: |
           python -m pip install setuptools
           python -m pip install babel
           python setup.py compile_catalog
+
+      - name: Compile catalog from package path
+        if: ${{ fromJSON(inputs.babel-compile-catalog) && inputs.backend-package-path != '' }}
+        env:
+          BACKEND_PACKAGE_PATH: ${{ inputs.backend-package-path }}
+        run: |
+          python -m pip install babel
+          TRANSLATION_DIRECTORY="${BACKEND_PACKAGE_PATH}/translations"
+          if [[ ! -d "$TRANSLATION_DIRECTORY" ]]
+          then
+            echo "given translation directory '$TRANSLATION_DIRECTORY' does not exist"
+            exit 1
+          fi
+          pybabel compile --directory="$TRANSLATION_DIRECTORY" --use-fuzzy
 
       - name: Determine JS translation directory
         id: determine_js_path


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Add a backend package path input for packages without setup.py catalog commands.
* Compile catalogs from the package translations directory with fuzzy entries enabled.
* Validate the translations directory before running Babel.

* related: https://github.com/inveniosoftware/invenio-app-rdm/issues/3499

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
